### PR TITLE
🐛 correctly set the config for S3 client

### DIFF
--- a/playground/Directory.Packages.props
+++ b/playground/Directory.Packages.props
@@ -17,7 +17,7 @@
 
   <ItemGroup Label="AWS">
     <PackageVersion Include="AWSSDK.Extensions.NETCore.Setup" Version="4.0.2.1" />
-    <PackageVersion Include="AWSSDK.S3" Version="4.0.6.7" />
+    <PackageVersion Include="AWSSDK.S3" Version="4.0.6.8" />
     <PackageVersion Include="LocalStack.Client.Extensions" Version="2.0.0" />
   </ItemGroup>
 

--- a/src/Aspire.Hosting.AWS.S3/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.AWS.S3/ResourceBuilderExtensions.cs
@@ -185,14 +185,19 @@ public static partial class ResourceBuilderExtensions
                 var rls = evt.Services.GetRequiredService<ResourceLoggerService>();
                 var logger = rls.GetLogger(evt.Resource);
                 var client = evt.Services.GetRequiredKeyedService<Amazon.S3.IAmazonS3>(evt.Resource.Name);
-                if (profile is not null && client.Config is Amazon.Runtime.ClientConfig config)
+                if (profile is not null)
                 {
                     // get the profile
                     var chain = new Amazon.Runtime.CredentialManagement.CredentialProfileStoreChain();
                     if (chain.TryGetAWSCredentials(profile, out var profileCredentials))
                     {
                         LogChangeProfile(logger, profile);
-                        config.DefaultAWSCredentials = profileCredentials;
+                        var config = client.Config as Amazon.S3.AmazonS3Config;
+                        client.Dispose();
+
+                        client = config is not null
+                            ? new Amazon.S3.AmazonS3Client(profileCredentials, config)
+                            : new(profileCredentials);
                     }
                 }
 

--- a/tests/Directory.Packages.props
+++ b/tests/Directory.Packages.props
@@ -11,7 +11,7 @@
   
   <ItemGroup Label="AWS">
     <PackageVersion Include="AWSSDK.Extensions.NETCore.Setup" Version="4.0.2.1" />
-    <PackageVersion Include="AWSSDK.S3" Version="4.0.6.7" />
+    <PackageVersion Include="AWSSDK.S3" Version="4.0.6.8" />
   </ItemGroup>
 
   <ItemGroup Label="Microsoft">


### PR DESCRIPTION
Due to a change in the client config setup in the AWS SDK, setting the default config after creating a client no longer works (it holds the credentials from what it was created). Rather than setting the profile globally, this finds the credentials, and creates a new client with the correct credentials.